### PR TITLE
Corrected scan function.

### DIFF
--- a/pyzigbee/gateways/gateway.py
+++ b/pyzigbee/gateways/gateway.py
@@ -90,7 +90,7 @@ class Gateway(object):
 
     def scan(self, delay=5):
         """
-        Scan the network and return a list of ZigBee IDs
+        Scan the network and return a list of dict (database Index, ZigBee ID)
         """
         self.driver.set_unblocking_mode()
 
@@ -101,7 +101,7 @@ class Gateway(object):
         self.logger.debug("%d device(s) on the network", dev_nb)
 
         # we can now loop over the devices
-        dev_ids = []
+        devices = []
         for i in range(0, dev_nb):
             try:
                 self.logger.debug("getting device ID at index %d...", i)
@@ -109,11 +109,11 @@ class Gateway(object):
                 answer = self._get_answer(sequence)
                 dev_id = self.protocol.decode_dev_id(answer)
                 self.logger.info("device ID at index %d: %s", i, dev_id)
-                dev_ids.append(dev_id)
+                devices.append({"index": i, "zigbee_id": dev_id})
             except PyZigBeeException as error:
                 self.logger.warn("failed to get device ID at index %d (%s)",
                                  i, error)
-        return dev_ids
+        return devices
 
     def receive(self, timeout=None):
         """

--- a/pyzigbee/protocols/openwebnet.py
+++ b/pyzigbee/protocols/openwebnet.py
@@ -85,8 +85,9 @@ class OWNProtocol(BaseProtocol):
         Build the frames sequence to get the device ID from
         a given device index
         """
-        return [{"tx": "*#13**66#%d##" % dev_index},
-                {"answer": ""}]
+        return [{"tx": "*#13**73#%d##" % dev_index},
+                {"answer": ""},
+                {"rx": OWN_ACK}, ]
 
     def decode_dev_id(self, data):
         """

--- a/pyzigbee/shell/pyzigbeesh.py
+++ b/pyzigbee/shell/pyzigbeesh.py
@@ -160,6 +160,15 @@ class PyZigBeeShell(cmd.Cmd):
         print(self.gateway.driver.read(to_read=arg))
 
     @handle_exception
+    def do_drv_receive(self, arg):
+        """
+        Receive frame from the network
+
+        Optional arg: number of seconds to block (no arg means infinite)
+        """
+        print(self.gateway.receive(timeout=arg))
+
+    @handle_exception
     def do_drv_write(self, arg):
         """
         Write data to the gateway driver (bypassing protocol encoding)

--- a/pyzigbee/shell/pyzigbeesh.py
+++ b/pyzigbee/shell/pyzigbeesh.py
@@ -104,10 +104,11 @@ class PyZigBeeShell(cmd.Cmd):
             arg = 5
 
         with closing(self.gateway.open()) as gateway:
-            zigbee_ids = gateway.scan(delay=arg)
+            zigbee_devices = gateway.scan(delay=arg)
 
-        for zigbee_id in zigbee_ids:
-            print(zigbee_id)
+        for zigbee_device in zigbee_devices:
+            print("index: %03d   id: %s" %
+                  (zigbee_device['index'], zigbee_device['zigbee_id']))
 
     @handle_exception
     def do_receive(self, arg):


### PR DESCRIPTION
# Scan function correction

The openwebnet command has been changed.

The previously used sequence "_#13_*66#%d##" would lead tom many answers for a single device, as it is a product configuration request.

The new sequence  "_#13_*73#%d##" is a product information request whose answer is a single line.

The rx sequence has also been introduced.
# New pyzigbeesh command

The drv_receive command has been created. It is equivalent to the receive command but it does not open/close the gateway.
it makes easier to view sequences:
(pyzigbeesh) drv_open
(pyzigbeesh) drv_write _#13__66#2##
(pyzigbeesh) drv_receive
*#13_8659261800#9_66#2_0##
(pyzigbeesh) drv_receive
_#13_8659261800#9_66#2_0##
(pyzigbeesh) drv_receive
_#13_8659261801#9_66#2_277##
(pyzigbeesh) drv_receive
_#13_8659261802#9_66#2_1284##
(pyzigbeesh) drv_receive
_#_1##
(pyzigbeesh) drv_close
(pyzigbeesh) 
